### PR TITLE
Include batch in error message

### DIFF
--- a/lib/batcher.rb
+++ b/lib/batcher.rb
@@ -1,7 +1,7 @@
 require 'batcher/null_logger'
 
 class Batcher
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
   StoppedError = Class.new(StandardError)
 
   def initialize(name, size, tick_period, on_error: nil, &block)


### PR DESCRIPTION
This is in relation to trying to hunt down some ASCII/UTF-8 conversion errors in mailers: https://www.pivotaltracker.com/story/show/132602009

The `debug` statement isn't making it to kibana for searching, so just include it in the original error message.

NO QA